### PR TITLE
Configure a custom token on stripe.js/v3 requests

### DIFF
--- a/lib/fake_stripe/stub_stripe_js.rb
+++ b/lib/fake_stripe/stub_stripe_js.rb
@@ -27,7 +27,16 @@ module FakeStripe
 
       content_type "text/javascript"
       status 200
-      IO.read(file_path)
+      js = IO.read(file_path)
+      if defined?(@@token)
+        js.gsub(/tok_123/, @@token)
+      else
+        js
+      end
+    end
+
+    post "/v3/" do
+      @@token = JSON.load(request.body).dig("token", "id")
     end
   end
 end

--- a/spec/fake_stripe/requests/stripe_js_spec.rb
+++ b/spec/fake_stripe/requests/stripe_js_spec.rb
@@ -33,5 +33,31 @@ describe "Stub Stripe JS" do
 
       expect(response).to include "class Element"
     end
+
+    context "POST v3" do
+      it "sets the token in requests" do
+        token = "tok_abc123"
+        url = URI.parse(STRIPE_JS_HOST)
+        url.path = "/v3/"
+
+        params = {
+          token: {
+            id: token,
+          }
+        }.to_json
+        http_post(url, params)
+
+        response = Net::HTTP.get(url)
+        expect(response).to include token
+      end
+    end
+  end
+
+  def http_post(uri, json)
+    header = {"Content-Type": "text/json"}
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Post.new(uri.request_uri, header)
+    request.body = json
+    http.request(request)
   end
 end


### PR DESCRIPTION
This PR allows the token on STRIPE_JS_HOST/v3/ requests to be dynamically configured in the spec by posting the token to the stripe.js server.

This change was really helpful for me because it allowed me to seamlessly integrate generated tokens from the stripe-mock into my integration tests.

Please let me know if you see a better way to do this! Happy to address and make this available to anyone who wants it.