### PR TITLE
Change token for v3

### DIFF
--- a/lib/fake_stripe/configuration.rb
+++ b/lib/fake_stripe/configuration.rb
@@ -1,11 +1,17 @@
 module FakeStripe
   module Configuration
     attr_writer :fixture_path
+    attr_writer :stripe_token
 
     DEFAULT_FIXTURE_PATH = File.join(File.dirname(__FILE__), 'fixtures/')
+    DEFAULT_TOKEN = 'tok_123'
 
     def fixture_path
       @fixture_path or DEFAULT_FIXTURE_PATH
+    end
+
+    def stripe_token
+      @stripe_token || DEFAULT_TOKEN
     end
 
     def configure

--- a/lib/fake_stripe/configuration.rb
+++ b/lib/fake_stripe/configuration.rb
@@ -1,17 +1,17 @@
 module FakeStripe
   module Configuration
     attr_writer :fixture_path
-    attr_writer :stripe_token
+    attr_writer :js_v3_token
 
     DEFAULT_FIXTURE_PATH = File.join(File.dirname(__FILE__), 'fixtures/')
-    DEFAULT_TOKEN = 'tok_123'
+    DEFAULT_TOKEN = "tok_123".freeze
 
     def fixture_path
       @fixture_path or DEFAULT_FIXTURE_PATH
     end
 
-    def stripe_token
-      @stripe_token || DEFAULT_TOKEN
+    def js_v3_token
+      @js_v3_token || DEFAULT_TOKEN
     end
 
     def configure

--- a/lib/fake_stripe/stub_stripe_js.rb
+++ b/lib/fake_stripe/stub_stripe_js.rb
@@ -28,15 +28,11 @@ module FakeStripe
       content_type "text/javascript"
       status 200
       js = IO.read(file_path)
-      if defined?(@@token)
-        js.gsub(/tok_123/, @@token)
+      if defined?(FakeStripe.js_v3_token)
+        js.gsub(/tok_123/, FakeStripe.js_v3_token)
       else
         js
       end
-    end
-
-    post "/v3/" do
-      @@token = JSON.load(request.body).dig("token", "id")
     end
   end
 end

--- a/spec/fake_stripe/configuration_spec.rb
+++ b/spec/fake_stripe/configuration_spec.rb
@@ -23,25 +23,25 @@ describe FakeStripe::Configuration, '#fixture_path' do
   end
 
   context 'when setting the stripe token' do
-    let!(:new_stripe_token) { 'abc123' }
-    let!(:previous_stripe_token) { FakeStripe.stripe_token }
+    let!(:new_js_v3_token) { 'abc123' }
+    let!(:previous_js_v3_token) { FakeStripe.js_v3_token }
 
     after do
       FakeStripe.configure do |config|
-        config.stripe_token = previous_stripe_token
+        config.js_v3_token = previous_js_v3_token
       end
     end
 
     it 'returns the config stripe token' do
       FakeStripe.configure do |config|
-        config.stripe_token = new_stripe_token
+        config.js_v3_token = new_js_v3_token
       end
 
-      expect(FakeStripe.stripe_token).to eq new_stripe_token
+      expect(FakeStripe.js_v3_token).to eq new_js_v3_token
     end
 
     it 'returns a default token' do
-      expect(FakeStripe.stripe_token).to eq 'tok_123'
+      expect(FakeStripe.js_v3_token).to eq 'tok_123'
     end
   end
 end

--- a/spec/fake_stripe/configuration_spec.rb
+++ b/spec/fake_stripe/configuration_spec.rb
@@ -1,22 +1,47 @@
 require 'spec_helper'
 
 describe FakeStripe::Configuration, '#fixture_path' do
-  let!(:new_fixture_path) { '/custom/fixture/path' }
-  let!(:previous_fixture_path) { FakeStripe.fixture_path }
+  context 'when setting the fixture_path' do
+    let!(:new_fixture_path) { '/custom/fixture/path' }
+    let!(:previous_fixture_path) { FakeStripe.fixture_path }
 
-  before do
-    FakeStripe.configure do |config|
-      config.fixture_path = new_fixture_path
+    before do
+      FakeStripe.configure do |config|
+        config.fixture_path = new_fixture_path
+      end
+    end
+
+    after do
+      FakeStripe.configure do |config|
+        config.fixture_path = previous_fixture_path
+      end
+    end
+
+    it 'returns the config fixture path' do
+      expect(FakeStripe.fixture_path).to eq new_fixture_path
     end
   end
 
-  after do
-    FakeStripe.configure do |config|
-      config.fixture_path = previous_fixture_path
-    end
-  end
+  context 'when setting the stripe token' do
+    let!(:new_stripe_token) { 'abc123' }
+    let!(:previous_stripe_token) { FakeStripe.stripe_token }
 
-  it 'returns the config fixture path' do
-    expect(FakeStripe.fixture_path).to eq new_fixture_path
+    after do
+      FakeStripe.configure do |config|
+        config.stripe_token = previous_stripe_token
+      end
+    end
+
+    it 'returns the config stripe token' do
+      FakeStripe.configure do |config|
+        config.stripe_token = new_stripe_token
+      end
+
+      expect(FakeStripe.stripe_token).to eq new_stripe_token
+    end
+
+    it 'returns a default token' do
+      expect(FakeStripe.stripe_token).to eq 'tok_123'
+    end
   end
 end

--- a/spec/fake_stripe/requests/stripe_js_spec.rb
+++ b/spec/fake_stripe/requests/stripe_js_spec.rb
@@ -34,17 +34,26 @@ describe "Stub Stripe JS" do
       expect(response).to include "class Element"
     end
 
-    it "sets the token in requests" do
-      custom_token = "abc123"
-      FakeStripe.configure do |config|
-        config.js_v3_token = custom_token
+    context "when a js_v3_token is set" do
+      let!(:previous_js_v3_token) { FakeStripe.js_v3_token }
+      after do
+        FakeStripe.configure do |config|
+          config.js_v3_token = previous_js_v3_token
+        end
       end
-      url = URI.parse(STRIPE_JS_HOST)
-      url.path = "/v3/"
 
-      response = Net::HTTP.get(url)
+      it "sets the token in requests" do
+        custom_token = "abc123"
+        FakeStripe.configure do |config|
+          config.js_v3_token = custom_token
+        end
+        url = URI.parse(STRIPE_JS_HOST)
+        url.path = "/v3/"
 
-      expect(response).to include custom_token
+        response = Net::HTTP.get(url)
+
+        expect(response).to include custom_token
+      end
     end
   end
 end

--- a/spec/fake_stripe/requests/stripe_js_spec.rb
+++ b/spec/fake_stripe/requests/stripe_js_spec.rb
@@ -34,22 +34,17 @@ describe "Stub Stripe JS" do
       expect(response).to include "class Element"
     end
 
-    context "POST v3" do
-      it "sets the token in requests" do
-        token = "tok_abc123"
-        url = URI.parse(STRIPE_JS_HOST)
-        url.path = "/v3/"
-
-        params = {
-          token: {
-            id: token,
-          }
-        }.to_json
-        http_post(url, params)
-
-        response = Net::HTTP.get(url)
-        expect(response).to include token
+    it "sets the token in requests" do
+      custom_token = "abc123"
+      FakeStripe.configure do |config|
+        config.js_v3_token = custom_token
       end
+      url = URI.parse(STRIPE_JS_HOST)
+      url.path = "/v3/"
+
+      response = Net::HTTP.get(url)
+
+      expect(response).to include custom_token
     end
   end
 end

--- a/spec/fake_stripe/requests/stripe_js_spec.rb
+++ b/spec/fake_stripe/requests/stripe_js_spec.rb
@@ -52,12 +52,4 @@ describe "Stub Stripe JS" do
       end
     end
   end
-
-  def http_post(uri, json)
-    header = {"Content-Type": "text/json"}
-    http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Post.new(uri.request_uri, header)
-    request.body = json
-    http.request(request)
-  end
 end


### PR DESCRIPTION
This changes the how we set the token on `fake_stripe`.  It will be set via a configure method instead of using a `POST`.