### PR TITLE
Adding Stripe validations for card

### DIFF
--- a/lib/fake_stripe/assets/v3.js
+++ b/lib/fake_stripe/assets/v3.js
@@ -50,6 +50,16 @@ window.Stripe = () => {
     return document.getElementById("stripe-cardnumber").value.substr(-4, 4);
   };
 
+  const errorMessage = () => {
+    if (document.getElementById("stripe-cardnumber").value === "") {
+      return "Your card number is incomplete";
+    } else if (document.getElementById("stripe-cardnumber").value === "4242424242424241") {
+      return "Your card number is invalid.";
+    } else { 
+      return null; 
+    }
+  }
+
   return {
     elements: () => {
       return {
@@ -59,7 +69,11 @@ window.Stripe = () => {
 
     createToken: card => {
       return new Promise(resolve => {
-        resolve({ token: { id: "tok_123", card: { last4: fetchLastFour() } } });
+        if (errorMessage() == null) {
+          resolve({ token: { id: "tok_123", card: { last4: fetchLastFour() } } });
+        } else { 
+          resolve({ error: { message: errorMessage() } });
+        }
       });
     }
   };

--- a/spec/fake_stripe/requests/stripe_js_spec.rb
+++ b/spec/fake_stripe/requests/stripe_js_spec.rb
@@ -55,5 +55,15 @@ describe "Stub Stripe JS" do
         expect(response).to include custom_token
       end
     end
+
+    it "returns field validation errors" do
+      url = URI.parse(STRIPE_JS_HOST)
+      url.path = "/v3/"
+      errors = "resolve({ error: { message: errorMessage() } })"
+
+      response = Net::HTTP.get(url)
+
+      expect(response).to include errors
+    end
   end
 end


### PR DESCRIPTION
This PR adds in Stripe card validations to fake_stripe so that we can eliminate one of our most flaky specs.